### PR TITLE
Redesign: modern, bold-blue visual system

### DIFF
--- a/.impeccable.md
+++ b/.impeccable.md
@@ -1,0 +1,41 @@
+# Impeccable
+
+Design context for **donebysimon.be** — Simon Vanherweghe's personal maker's blog.
+This file guides all design work on the site. Read it before building or changing any UI.
+
+## Design Context
+
+### Users
+
+- **Primary**: casual visitors curious about what Simon makes — fellow makers and developers, students (Simon lectures in web development and creative code), and people who received one of his physical projects (plotter cards, bots, crafts) and came to see the story behind it.
+- **Secondary**: people sizing Simon up professionally — collaborators, event organisers, the curious-after-a-talk.
+- **Context of use**: browsing casually — during a break, from a link in a class/talk/social post. Not task-driven; they came to look, read a story, and enjoy.
+- **Job to be done**: quickly get a feel for who Simon is and what he makes; enjoy one project's story end to end; be delighted enough to open another.
+
+### Brand Personality
+
+- **Voice** (unchanged): a first-person maker's log — humble, playful, self-deprecating ("Mostly experiments, occasionally finished."). Shows the pile of failed tests, not only the glossy shot. English posts, a Dutch archive.
+- **Visual register**: modern, fresh, subtle, confident. Clean and quiet, with one bold moment. NOT loud, NOT retro, NOT "handmade/craft-textured", NOT warm-toned.
+
+### Aesthetic Direction (shipped)
+
+- **Type**: **Bricolage Grotesque** (display — wordmark, hero, titles; heavy weight ~800, tight tracking), **Hanken Grotesk** (body/reading), **Fragment Mono** (small metadata ONLY — dates, tags, counts, the `Nº` index). All self-hosted via `@fontsource` (no CDNs). No fantasy/antiqued serifs.
+- **Palette** — OKLCH, cool and modern: a **cool near-white** paper (NOT warm cream), cool blue-black **ink**, and a **single blue accent** (a riso-ish blue). Neutrals tinted toward the blue (hue ~258–262). No orange, no second accent. Full **light + dark** (dark = clean cool-dark ground, blue stays the accent). Tokens live in `src/css/tokens.css`.
+- **Signature**: one **bold solid-blue hero block** carrying a big cream Bricolage headline (`Things done, by Simon.`, no tagline) — the single loud moment. Everywhere else blue is a **quiet accent**: links, hover underlines, the wordmark dot. Project photos stay **full-colour** and lead the work. Generous whitespace, thin hairline rules. No section labels, no post numbering, no colophon line — kept deliberately spare.
+- **Interaction**: quiet. Hover/focus = a blue title underline. **No image hover-zoom** (reads as AI slop), no colour-blocking, no textures, no duotone.
+- **Anti-references** — must NOT look like: warm/cream backgrounds, riso poster colour-blocking or orange, a "ledger/contact-sheet" of crop marks, fantasy serifs, or the AI tells (hover-scale, gradient text, glassmorphism, `border-left` accent stripes, uniform icon+heading cards).
+
+### Design Principles
+
+1. **One bold moment, quiet everywhere else** — the blue hero is the statement; the rest breathes.
+2. **Blue is the only accent** — used sparingly so it stays meaningful; no second colour.
+3. **Cool, modern, fresh** — cool near-white and cool neutrals; never warm.
+4. **Legible first** — long-form reading matters; protect measure (~65–75ch), contrast, rhythm.
+5. **No AI tells** — no hover-zoom, no gradient text, no glassmorphism, no side-stripe borders.
+6. **Both themes as equals; accessibility stays in the DNA** — real alt text, visible focus, honored `prefers-reduced-motion`, WCAG-AA in both themes (verified with an OKLCH contrast validator).
+
+### Technical Constraints
+
+- **Stack**: Astro 5 static site → GitHub Pages (push to `main` → `gh-pages` → live). Self-hosted fonts via `@fontsource` only.
+- **Foundations**: fluid (Utopia) `--step-*` / `--space-*` scales and legacy-name colour tokens in `src/css/tokens.css`; content measure `45rem`, container `75rem`; scoped `<style>` per component. Theme = `prefers-color-scheme` + a persisted manual toggle (`ThemeToggle.astro`), applied via `data-theme` with a no-flash head script.
+- **Public repo** — no session links / private trailers in commits.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,44 @@
+# donebysimon.be
+
+Simon Vanherweghe's personal maker's blog. Astro 5 static site deployed to GitHub Pages
+(push to `main` → `gh-pages` → live at https://donebysimon.be). Posts are a first-person log
+of creative-coding and craft projects (plotters, bots, cards, games). English posts, a Dutch
+archive. Public repo — no session links or private trailers in commits.
+
+Design work is governed by the Design Context below (fuller version in `.impeccable.md`).
+Read it before building or changing any UI.
+
+## Design Context
+
+### Users
+Casual visitors curious about what Simon makes — makers, developers, students (he lectures in
+web dev / creative code), and people who received a physical project. Browsing casually to read
+a story and enjoy, not task-driven.
+
+### Voice vs. visual
+- **Voice**: humble, playful, self-deprecating maker's log ("Mostly experiments, occasionally
+  finished."). Shows the failures.
+- **Visual register**: modern, fresh, subtle, confident. Clean and quiet with one bold moment.
+  NOT warm-toned, NOT retro, NOT craft-textured, NOT loud.
+
+### Aesthetic (shipped)
+- **Type**: Bricolage Grotesque (display — wordmark/hero/titles, heavy ~800), Hanken Grotesk
+  (body), Fragment Mono (small metadata only: dates, tags, counts, `Nº`). Self-hosted via
+  `@fontsource`. No fantasy/antiqued serifs.
+- **Palette** (OKLCH, `src/css/tokens.css`): cool near-white paper (NOT warm cream), cool
+  blue-black ink, a single **blue** accent (riso-ish). Neutrals tinted toward blue. No orange.
+  Full light + dark (cool dark).
+- **Signature**: one bold solid-blue hero block with a big cream Bricolage headline (no
+  tagline); blue as a quiet accent everywhere else (links, hover underlines, wordmark dot).
+  Full-colour project photos lead. Whitespace + thin hairline rules. Kept spare: no section
+  labels, no post numbering, no colophon line.
+- **Interaction**: quiet — hover/focus = a blue title underline. No image hover-zoom.
+
+### Principles
+1. One bold moment (the blue hero), quiet everywhere else.
+2. Blue is the only accent — used sparingly.
+3. Cool, modern, fresh — never warm.
+4. Legible first (measure ~65–75ch, contrast, rhythm).
+5. No AI tells — no hover-zoom, gradient text, glassmorphism, or side-stripe borders.
+6. Both themes as equals; accessibility in the DNA (alt text, visible focus, reduced-motion,
+   WCAG-AA verified in both themes).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,19 @@
 {
-  "name": "new",
+  "name": "donebysimon",
   "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "new",
+      "name": "donebysimon",
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "@astrojs/rss": "^4.0.15",
         "@astrojs/sitemap": "^3.7.0",
-        "@fontsource-variable/roboto-slab": "^5.2.8",
+        "@fontsource-variable/bricolage-grotesque": "^5.2.10",
+        "@fontsource-variable/hanken-grotesk": "^5.2.8",
+        "@fontsource/fragment-mono": "^5.2.8",
         "astro": "^5.17.3",
         "astro-og-canvas": "^0.10.0",
         "markdown-it": "^14.1.0",
@@ -21,6 +23,9 @@
       "devDependencies": {
         "@astrojs/check": "^0.9.9",
         "typescript": "^5.9.3"
+      },
+      "engines": {
+        "node": ">=22"
       }
     },
     "node_modules/@astrojs/check": {
@@ -762,11 +767,29 @@
         "node": ">=18"
       }
     },
-    "node_modules/@fontsource-variable/roboto-slab": {
+    "node_modules/@fontsource-variable/bricolage-grotesque": {
+      "version": "5.2.10",
+      "resolved": "https://registry.npmjs.org/@fontsource-variable/bricolage-grotesque/-/bricolage-grotesque-5.2.10.tgz",
+      "integrity": "sha512-5EDsCqgGpKVcJWE4sg9ydli+t5WM97mISYw5lla/Ev4z71FwXh1oN0YUU8xjkRW9+wBCGD9R+ntAvI8G4bUFJg==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource-variable/hanken-grotesk": {
       "version": "5.2.8",
-      "resolved": "https://registry.npmjs.org/@fontsource-variable/roboto-slab/-/roboto-slab-5.2.8.tgz",
-      "integrity": "sha512-cdvOSwocP50xS01gXqnGxw7uFcCZQgn1IDlqiAmNuZP4uEVScYAKMDC+aWsbP1grn9QdMJ2frhcuVBNXniBVGA==",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@fontsource-variable/hanken-grotesk/-/hanken-grotesk-5.2.8.tgz",
+      "integrity": "sha512-K7hu09ZKReBc7EifRLeM4K94NZBrxFEg0nGcISmVwlFQOJo4EmYkLXTWEwr5JcNW4z2hr5zy8vLS2sxC8JDmrQ==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource/fragment-mono": {
+      "version": "5.2.8",
+      "resolved": "https://registry.npmjs.org/@fontsource/fragment-mono/-/fragment-mono-5.2.8.tgz",
+      "integrity": "sha512-m+aRQ+c9GghoUtEdSFIPM/ylCxDhY5ESeVzuvF+eSCqkR85VSCWM7jnNWZ+OrC9K2+xp6f0uallDDAjmPLQNrQ==",
+      "license": "OFL-1.1",
       "funding": {
         "url": "https://github.com/sponsors/ayuhito"
       }
@@ -7167,10 +7190,20 @@
       "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
       "optional": true
     },
-    "@fontsource-variable/roboto-slab": {
+    "@fontsource-variable/bricolage-grotesque": {
+      "version": "5.2.10",
+      "resolved": "https://registry.npmjs.org/@fontsource-variable/bricolage-grotesque/-/bricolage-grotesque-5.2.10.tgz",
+      "integrity": "sha512-5EDsCqgGpKVcJWE4sg9ydli+t5WM97mISYw5lla/Ev4z71FwXh1oN0YUU8xjkRW9+wBCGD9R+ntAvI8G4bUFJg=="
+    },
+    "@fontsource-variable/hanken-grotesk": {
       "version": "5.2.8",
-      "resolved": "https://registry.npmjs.org/@fontsource-variable/roboto-slab/-/roboto-slab-5.2.8.tgz",
-      "integrity": "sha512-cdvOSwocP50xS01gXqnGxw7uFcCZQgn1IDlqiAmNuZP4uEVScYAKMDC+aWsbP1grn9QdMJ2frhcuVBNXniBVGA=="
+      "resolved": "https://registry.npmjs.org/@fontsource-variable/hanken-grotesk/-/hanken-grotesk-5.2.8.tgz",
+      "integrity": "sha512-K7hu09ZKReBc7EifRLeM4K94NZBrxFEg0nGcISmVwlFQOJo4EmYkLXTWEwr5JcNW4z2hr5zy8vLS2sxC8JDmrQ=="
+    },
+    "@fontsource/fragment-mono": {
+      "version": "5.2.8",
+      "resolved": "https://registry.npmjs.org/@fontsource/fragment-mono/-/fragment-mono-5.2.8.tgz",
+      "integrity": "sha512-m+aRQ+c9GghoUtEdSFIPM/ylCxDhY5ESeVzuvF+eSCqkR85VSCWM7jnNWZ+OrC9K2+xp6f0uallDDAjmPLQNrQ=="
     },
     "@img/colour": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
   "dependencies": {
     "@astrojs/rss": "^4.0.15",
     "@astrojs/sitemap": "^3.7.0",
-    "@fontsource-variable/roboto-slab": "^5.2.8",
+    "@fontsource-variable/bricolage-grotesque": "^5.2.10",
+    "@fontsource-variable/hanken-grotesk": "^5.2.8",
+    "@fontsource/fragment-mono": "^5.2.8",
     "astro": "^5.17.3",
     "astro-og-canvas": "^0.10.0",
     "markdown-it": "^14.1.0",

--- a/src/components/ArchiveList.astro
+++ b/src/components/ArchiveList.astro
@@ -24,10 +24,38 @@ const dateOptions = {
 </ul>
 
 <style>
+  .archivelist {
+    max-width: var(--max-width-content);
+  }
+
   li {
     display: grid;
-    grid-template-columns: 15ch auto;
+    grid-template-columns: 12ch auto;
+    gap: var(--space-s);
+    align-items: baseline;
+    padding-block: var(--space-2xs);
+    border-bottom: 1px solid var(--rule);
+  }
+
+  time {
+    font-family: var(--font-mono);
+    font-size: var(--step--2);
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    color: var(--ink-faint);
     font-variant-numeric: tabular-nums;
-    margin-bottom: var(--space-3xs);
+  }
+
+  .postlist-link {
+    color: var(--color-text);
+    text-decoration: none;
+    font-weight: 500;
+  }
+
+  .postlist-link:hover {
+    color: var(--blue-ink);
+    text-decoration: underline;
+    text-decoration-color: var(--blue);
+    text-underline-offset: 0.2em;
   }
 </style>

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,67 +1,96 @@
-<footer>
-  <div>
-    <ul class="footer__links">
-      <li>
-        <a
-          href="https://www.instagram.com/donebysimon/"
-          target="_blank"
-          rel="noopener noreferrer">Instagram</a
-        >
-      </li>
-      <li>
-        <a
-          href="https://github.com/simonvanherweghe"
-          target="_blank"
-          rel="noopener noreferrer">GitHub</a
-        >
-      </li>
-      <li>
-        <a
-          href="https://bsky.app/profile/donebysimon.be"
-          target="_blank"
-          rel="noopener noreferrer">Bluesky</a
-        >
-      </li>
-      <li>
-        <a href="/feed.xml">RSS</a>
-      </li>
+---
+const links = [
+  { label: "Instagram", href: "https://www.instagram.com/donebysimon/", external: true },
+  { label: "GitHub", href: "https://github.com/simonvanherweghe", external: true },
+  { label: "Bluesky", href: "https://bsky.app/profile/donebysimon.be", external: true },
+  { label: "RSS", href: "/feed.xml", external: false },
+  { label: "The Archive", href: "/archive", external: false },
+];
+---
 
-      <li>
-        <a href="/archive">The Archive</a>
-      </li>
-    </ul>
+<footer class="colophon">
+  <div class="colophon__inner">
+    <hr />
+    <div class="colophon__grid">
+      <div class="colophon__brand">
+        <a class="colophon__word" href="/">donebysimon<span class="colophon__dot">.</span></a>
+      </div>
+
+      <nav class="colophon__nav" aria-label="Find Simon elsewhere">
+        <ul>
+          {
+            links.map((link) => (
+              <li>
+                <a
+                  href={link.href}
+                  {...(link.external
+                    ? { target: "_blank", rel: "noopener noreferrer" }
+                    : {})}
+                >
+                  {link.label}
+                </a>
+              </li>
+            ))
+          }
+        </ul>
+      </nav>
+    </div>
   </div>
 </footer>
 
 <style>
-  footer {
-    background-color: var(--color-text);
-    padding: var(--space-l) var(--space-xs);
-
-    color: var(--color-bg);
+  .colophon {
+    margin-top: var(--space-3xl);
+    padding-inline: var(--space-xs);
   }
 
-  div {
+  .colophon__inner {
+    max-width: var(--max-width);
+    margin: 0 auto;
+  }
+
+  .colophon__grid {
     display: flex;
-    flex-flow: column nowrap;
-    align-items: center;
-    gap: var(--space-l);
+    flex-wrap: wrap;
+    justify-content: space-between;
+    align-items: start;
+    gap: var(--space-m);
+    padding-block: var(--space-m) var(--space-2xl);
   }
 
-  a:any-link {
-    color: inherit;
-  }
-
-  ul {
-    display: flex;
-    flex-flow: row wrap;
-    justify-content: center;
-  }
-
-  li:has(+ li)::after {
-    content: "\2022";
+  .colophon__word {
+    font-family: var(--font-display);
+    font-weight: 800;
+    font-size: var(--step-1);
+    letter-spacing: -0.03em;
+    color: var(--color-text);
+    text-decoration: none;
     display: inline-block;
-    width: 2ch;
-    text-align: center;
+  }
+  .colophon__dot { color: var(--blue); }
+
+  .colophon__nav ul {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-2xs) 0;
+  }
+
+  .colophon__nav a {
+    font-family: var(--font-body);
+    font-weight: 600;
+    font-size: var(--step--1);
+    color: var(--ink-soft);
+    text-decoration: none;
+    padding-inline: var(--space-xs);
+  }
+  .colophon__nav li:first-child a { padding-inline-start: 0; }
+  .colophon__nav li:not(:last-child) a {
+    border-right: 1px solid var(--rule);
+  }
+  .colophon__nav a:hover {
+    color: var(--color-accent);
+    text-decoration: underline;
+    text-decoration-color: var(--color-spark);
+    text-underline-offset: 0.25em;
   }
 </style>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -1,58 +1,87 @@
-<header>
-  <div>
-    <p class="sitetitle">
-      <a href="/"> DONEBYSIMON</a>
-    </p>
+---
+import ThemeToggle from "./ThemeToggle.astro";
+---
 
-    <nav aria-label="Main">
+<header class="masthead">
+  <div class="masthead__inner">
+    <a class="wordmark" href="/">
+      donebysimon<span class="wordmark__dot" aria-hidden="true">.</span>
+    </a>
+
+    <nav class="mainnav" aria-label="Main">
       <ul>
-        <li>
-          <a href="/blog">Blog</a>
-        </li>
-        <li>
-          <a href="/about">About</a>
-        </li>
+        <li><a href="/blog">Blog</a></li>
+        <li><a href="/about">About</a></li>
       </ul>
+      <ThemeToggle />
     </nav>
   </div>
+  <hr class="masthead__rule" />
 </header>
 
 <style>
-  header {
-    border-bottom: var(--border);
-    padding-bottom: var(--space-s);
-    margin-bottom: var(--space-m);
+  .masthead {
+    padding-inline: var(--space-xs);
   }
 
-  a:any-link {
-    text-decoration: none;
-    color: var(--color-text);
-  }
-
-  a:hover {
-    text-decoration: underline;
-  }
-
-  div {
+  .masthead__inner {
+    max-width: var(--max-width);
+    margin: 0 auto;
     display: flex;
     flex-wrap: wrap;
     justify-content: space-between;
-    align-items: baseline;
+    align-items: center;
+    gap: var(--space-s) var(--space-m);
+    padding-block: var(--space-m) var(--space-s);
+  }
 
-    padding: var(--space-xs);
-    margin: 0 auto;
+  .masthead__rule {
     max-width: var(--max-width);
+    margin: 0 auto;
   }
 
-  .sitetitle {
+  .wordmark {
+    font-family: var(--font-display);
+    font-weight: 800;
     font-size: var(--step-2);
-    font-weight: 400;
-    text-transform: uppercase;
-    margin: var(--space-m) 0;
+    line-height: 1;
+    letter-spacing: -0.03em;
+    color: var(--color-text);
+    text-decoration: none;
+    font-variation-settings: 'opsz' 24;
+  }
+  .wordmark__dot {
+    color: var(--blue);
+  }
+  .wordmark:hover .wordmark__dot {
+    color: var(--ink-soft);
   }
 
-  ul {
+  .mainnav {
     display: flex;
+    align-items: center;
     gap: var(--space-s);
+  }
+
+  .mainnav ul {
+    display: flex;
+    gap: var(--space-xs);
+  }
+
+  .mainnav a {
+    font-family: var(--font-body);
+    font-weight: 600;
+    font-size: var(--step--1);
+    letter-spacing: 0.02em;
+    color: var(--ink-soft);
+    text-decoration: none;
+    padding: var(--space-3xs) var(--space-2xs);
+  }
+  .mainnav a:hover {
+    color: var(--color-text);
+    text-decoration: underline;
+    text-decoration-color: var(--color-spark);
+    text-underline-offset: 0.25em;
+    text-decoration-thickness: 2px;
   }
 </style>

--- a/src/components/Post.astro
+++ b/src/components/Post.astro
@@ -1,81 +1,141 @@
 ---
 import PreviewImage from "./PreviewImage.astro";
-import TagsList from "./TagsList.astro";
 const { post, index } = Astro.props;
 
 // The first card spans the full grid and is the homepage LCP element. The rest sit below the
 // fold in narrower columns, so they can be fetched lazily at a smaller size.
 const isLead = index === 0;
+const dateLabel = post.data.date.toLocaleDateString("en-GB", {
+  day: "2-digit",
+  month: "short",
+  year: "numeric",
+});
 ---
 
-<article>
-  <a href={`/${post.data.permalink}`}>
-    <PreviewImage
-      image={post.data.preview}
-      alt={post.data.alt ?? ""}
-      priority={isLead}
-      width={isLead ? 1200 : 700}
-      sizes={isLead
-        ? "(min-width: 950px) 66vw, 100vw"
-        : "(min-width: 950px) 30vw, (min-width: 700px) 45vw, 100vw"}
-    />
-    <div class="tagslist">
-      <TagsList tags={post.data.tags} isLink={false} />
+<article class="entry" class:list={[{ "is-lead": isLead }]}>
+  <a class="entry__link" href={`/${post.data.permalink}`}>
+    <div class="entry__figure">
+      <div class="entry__frame">
+        <PreviewImage
+          image={post.data.preview}
+          alt={post.data.alt ?? ""}
+          priority={isLead}
+          width={isLead ? 1200 : 700}
+          sizes={isLead
+            ? "(min-width: 950px) 66vw, 100vw"
+            : "(min-width: 950px) 30vw, (min-width: 700px) 45vw, 100vw"}
+        />
+      </div>
     </div>
-    <h3>{post.data.title}</h3>
-    <p>{post.data.description}</p>
-    <div class="meta">
-      <time datetime={post.data.date.toISOString()}>
-        {post.data.date.toLocaleDateString("nl-BE")}
-      </time>
+
+    <div class="entry__body">
+      <h3 class="entry__title">{post.data.title}</h3>
+      <p class="entry__desc">{post.data.description}</p>
+      <div class="entry__meta">
+        <time class="tabular" datetime={post.data.date.toISOString()}>{dateLabel}</time>
+        <span class="entry__tags">
+          {post.data.tags.map((tag) => <span class="entry__tag">#{tag}</span>)}
+        </span>
+      </div>
     </div>
   </a>
 </article>
 
 <style>
-  .tagslist {
-    grid-area: tags;
+  .entry {
+    animation: entry-in var(--dur-slow) var(--ease-out-quint) both;
+    animation-delay: calc(var(--i, 0) * 55ms);
   }
 
-  a {
+  .entry__link {
+    display: block;
     text-decoration: none;
     color: inherit;
   }
 
-  a:hover h3 {
-    text-decoration: underline;
+  .entry__figure {
+    margin-bottom: var(--space-s);
   }
 
-  @container (min-width: 700px) {
-    a {
+  .entry__frame {
+    overflow: hidden;
+  }
+
+  .entry__frame :global(img) {
+    display: block;
+    width: 100%;
+    aspect-ratio: 16 / 8;
+    object-fit: cover;
+  }
+
+  .entry__title {
+    font-family: var(--font-display);
+    font-weight: 800;
+    font-size: var(--step-2);
+    line-height: 1.0;
+    letter-spacing: -0.02em;
+    color: var(--color-text);
+    margin-bottom: var(--space-2xs);
+    font-variation-settings: 'opsz' 30;
+  }
+
+  .entry__desc {
+    color: var(--ink-soft);
+    font-size: var(--step-0);
+    line-height: 1.45;
+    max-width: 60ch;
+    margin-bottom: var(--space-s);
+  }
+
+  .entry__meta {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    gap: var(--space-2xs) var(--space-s);
+    font-family: var(--font-mono);
+    font-size: var(--step--2);
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--ink-faint);
+  }
+
+  .entry__tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-2xs);
+  }
+  .entry__tag {
+    color: var(--ink-soft);
+  }
+
+  /* Clean hover / keyboard-focus feedback: title underlines in blue. No zoom. */
+  .entry__link:hover .entry__title,
+  .entry__link:focus-visible .entry__title {
+    text-decoration: underline;
+    text-decoration-color: var(--blue);
+    text-decoration-thickness: 2px;
+    text-underline-offset: 0.1em;
+  }
+
+  /* Lead entry: bigger, two columns once the container is wide. */
+  .is-lead .entry__title {
+    font-size: var(--step-4);
+  }
+
+  @container (min-width: 42rem) {
+    .is-lead .entry__link {
       display: grid;
-      gap: 0 var(--space-m);
-      align-items: start;
-      grid-template-columns: 2.1fr 1fr;
-      grid-template-rows: repeat(3, min-content) 1fr;
-      grid-template-areas:
-        "img tags"
-        "img title"
-        "img excerpt"
-        "img meta";
+      grid-template-columns: 1.6fr 1fr;
+      gap: var(--space-l);
+      align-items: center;
+    }
+    .is-lead .entry__figure {
+      margin-bottom: 0;
     }
   }
 
-  h3 {
-    font-size: var(--step-2);
-    font-weight: 400;
-    margin-bottom: var(--space-xs);
-    grid-area: title;
-  }
-
-  p {
-    margin-bottom: var(--space-s);
-    grid-area: excerpt;
-  }
-
-  .meta {
-    color: var(--color-grey);
-    font-size: var(--step--1);
-    grid-area: meta;
+  @keyframes entry-in {
+    from { opacity: 0; transform: translateY(10px); }
+    to   { opacity: 1; transform: translateY(0); }
   }
 </style>

--- a/src/components/PostsList.astro
+++ b/src/components/PostsList.astro
@@ -6,7 +6,7 @@ const { posts } = Astro.props;
 <ul class="post-list">
   {
     posts.map((post, index) => (
-      <li>
+      <li style={`--i:${Math.min(index, 8)}`}>
         <Post post={post} index={index} />
       </li>
     ))
@@ -18,12 +18,12 @@ const { posts } = Astro.props;
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(18rem, 1fr));
     justify-content: center;
-    gap: var(--space-m);
+    gap: var(--space-l) var(--space-m);
     margin-bottom: var(--space-m);
   }
 
   li {
-    margin-bottom: var(--space-2xl);
+    margin-bottom: var(--space-xl);
     container-type: inline-size;
   }
 

--- a/src/components/PreviewImage.astro
+++ b/src/components/PreviewImage.astro
@@ -24,9 +24,9 @@ const {
 
 <style>
   img {
+    display: block;
+    width: 100%;
     aspect-ratio: 16/8;
     object-fit: cover;
-    margin-bottom: var(--space-xs);
-    grid-area: img;
   }
 </style>

--- a/src/components/TagsList.astro
+++ b/src/components/TagsList.astro
@@ -16,20 +16,24 @@ const { tags, isLink = true } = Astro.props;
   ul {
     display: flex;
     flex-wrap: wrap;
-    gap: var(--space-xs);
-    font-size: var(--step--1);
-    color: var(--color-grey);
-    margin-bottom: var(--space-xs);
+    gap: var(--space-2xs) var(--space-s);
+    font-family: var(--font-mono);
+    font-size: var(--step--2);
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--ink-faint);
+    margin-bottom: var(--space-s);
   }
 
   a {
     text-decoration: none;
-    padding: var(--space-3xs) var(--space-2xs);
-    border-radius: 0.5em;
+    color: var(--ink-soft);
   }
 
   a:hover {
-    background-color: var(--color-accent);
-    color: var(--color-bg);
+    color: var(--blue-ink);
+    text-decoration: underline;
+    text-decoration-color: var(--blue);
+    text-underline-offset: 0.2em;
   }
 </style>

--- a/src/components/ThemeToggle.astro
+++ b/src/components/ThemeToggle.astro
@@ -1,0 +1,64 @@
+---
+// Flips an explicit light/dark preference on <html data-theme> and persists it.
+// With no stored preference the CSS prefers-color-scheme rules govern (auto).
+---
+
+<button class="theme-toggle" type="button" aria-label="Switch between light and dark theme" title="Switch theme">
+  <svg class="icon icon-sun" viewBox="0 0 24 24" width="20" height="20" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round">
+    <circle cx="12" cy="12" r="4.2"></circle>
+    <path d="M12 2.5v2.4M12 19.1v2.4M4.4 4.4l1.7 1.7M17.9 17.9l1.7 1.7M2.5 12h2.4M19.1 12h2.4M4.4 19.6l1.7-1.7M17.9 6.1l1.7-1.7"></path>
+  </svg>
+  <svg class="icon icon-moon" viewBox="0 0 24 24" width="20" height="20" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M20 14.5A8 8 0 0 1 9.5 4a6.5 6.5 0 1 0 10.5 10.5z"></path>
+  </svg>
+</button>
+
+<style>
+  .theme-toggle {
+    display: inline-grid;
+    place-items: center;
+    width: 2.75rem;
+    height: 2.75rem;
+    background: transparent;
+    border: 1px solid var(--rule);
+    color: var(--ink-soft);
+    cursor: pointer;
+    transition:
+      color var(--dur-fast) var(--ease-out-quart),
+      border-color var(--dur-fast) var(--ease-out-quart);
+  }
+
+  .theme-toggle:hover {
+    color: var(--color-spark);
+    border-color: var(--color-spark);
+  }
+
+  .icon { display: block; }
+
+  /* Show the icon for the currently effective theme. */
+  .icon-moon { display: none; }
+  @media (prefers-color-scheme: dark) {
+    :root:not([data-theme='light']) .icon-sun { display: none; }
+    :root:not([data-theme='light']) .icon-moon { display: block; }
+  }
+  :root[data-theme='dark'] .icon-sun { display: none; }
+  :root[data-theme='dark'] .icon-moon { display: block; }
+  :root[data-theme='light'] .icon-sun { display: block; }
+  :root[data-theme='light'] .icon-moon { display: none; }
+</style>
+
+<script>
+  function prefersDark() {
+    return window.matchMedia('(prefers-color-scheme: dark)').matches;
+  }
+  function currentTheme() {
+    return document.documentElement.dataset.theme || (prefersDark() ? 'dark' : 'light');
+  }
+  document.querySelectorAll('.theme-toggle').forEach((btn) => {
+    btn.addEventListener('click', () => {
+      const next = currentTheme() === 'dark' ? 'light' : 'dark';
+      document.documentElement.dataset.theme = next;
+      try { localStorage.setItem('theme', next); } catch (e) {}
+    });
+  });
+</script>

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -5,7 +5,11 @@
 
 html {
   box-sizing: border-box;
+  color-scheme: light dark;
 }
+:root[data-theme='light'] { color-scheme: light; }
+:root[data-theme='dark'] { color-scheme: dark; }
+
 *, *::before, *::after {
   box-sizing: inherit;
 }
@@ -13,6 +17,56 @@ html {
 img {
   max-inline-size: 100%;
   block-size: auto;
+}
+
+body {
+  background-color: var(--color-bg);
+}
+
+main {
+  padding: var(--space-xs);
+  margin: 0 auto;
+  max-width: var(--max-width);
+  width: 100%;
+}
+
+.layout-wrapper {
+  min-height: 100vh;
+  display: grid;
+  grid-template-rows: auto 1fr auto;
+}
+
+.page {
+  max-width: var(--max-width-content);
+  margin: 0 auto;
+}
+
+/* ---- Links ---- */
+a:any-link {
+  color: var(--color-accent);
+  text-underline-offset: 0.15em;
+  text-decoration-thickness: 1px;
+}
+a:hover {
+  text-decoration-color: var(--color-spark);
+  text-decoration-thickness: 2px;
+}
+
+::selection {
+  background: var(--blue);
+  color: var(--on-blue);
+}
+
+:focus-visible {
+  outline: 2px solid var(--blue);
+  outline-offset: 2px;
+}
+
+hr {
+  border: 0;
+  height: 1px;
+  width: 100%;
+  background: var(--rule-strong);
 }
 
 .visually-hidden {
@@ -30,46 +84,31 @@ img {
   position: absolute;
   left: var(--space-xs);
   top: 0;
-  z-index: 1;
+  z-index: 10;
   padding: var(--space-2xs) var(--space-xs);
-  background-color: var(--color-bg);
-  transform: translateY(-100%);
+  background-color: var(--blue);
+  color: var(--on-blue);
+  font-family: var(--font-mono);
+  font-size: var(--step--1);
+  transform: translateY(-120%);
 }
-
 .skip-link:focus {
   transform: translateY(0);
 }
 
-body {
-  background-color: var(--color-bg);
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.01ms !important;
+    animation-delay: 0ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
 }
 
-main {
-  padding: var(--space-xs);
-  margin: 0 auto;
-  max-width: var(--max-width);
-  width: 100%;
-}
-
-a:any-link {
-  color: var(--color-accent);
-}
-
-a:hover{
-  color: var(--color-accent);
-  text-decoration-color:var(--color-accent);
-  text-decoration-style: double;
-}
-
-.layout-wrapper {
-  min-height: 100vh; 
-  display: grid;
-  grid-template-rows: auto 1fr auto; 
-}
-
-.page {
-  max-width: var(--max-width-content);
-  margin: 0 auto;
+/* Post-page hero image (src/pages/[...slug].astro). */
+.headerimg {
+  margin-block: var(--space-s) var(--space-l);
 }
 
 /* Injected by the embedded GitHub gist script in 2023-05-03-textivalkrant.md. */

--- a/src/css/markdown.css
+++ b/src/css/markdown.css
@@ -5,8 +5,9 @@
   }
 
   & h2{
-    font-size: var(--step-3);
-    font-weight: 400;
+    font-size: var(--step-2);
+    font-weight: 600;
+    letter-spacing: -0.02em;
     margin-bottom: var(--space-3xs);
     margin-top: var(--space-l)
   }
@@ -29,14 +30,15 @@
   }
 
   & blockquote {
-    border-left: 4px solid var(--color-grey);
-    padding-left: var(--space-s);
-    margin-left: var(--space-s);
+    padding: var(--space-s) var(--space-m);
     margin-bottom: var(--space-m);
+    background: var(--paper-sunk);
+    color: var(--ink-soft);
+    font-style: italic;
   }
 
   & strong {
-    font-weight: 400;
+    font-weight: 700;
   }
 
   & img {
@@ -45,8 +47,10 @@
   }
 
   & code {
-    font-family: 'Courier New', Courier, monospace;
-    font-weight: bold;
+    font-family: var(--font-mono);
+    font-size: 0.86em;
+    background: var(--paper-sunk);
+    padding: 0.1em 0.35em;
   }
 
   & em {

--- a/src/css/tokens.css
+++ b/src/css/tokens.css
@@ -1,14 +1,54 @@
 :root {
-  --color-text: rgb(41, 41, 41);
-  --color-mid: rgb(189, 189, 189);
-  --color-grey: #979797;
-  --color-accent: #0074d9;
-  --color-bg: #fffffe;
+  /* ----------------------------------------------------------------------
+     Type — Bricolage Grotesque (display), Hanken Grotesk (body), Fragment
+     Mono (tiny metadata only). Self-hosted via @fontsource.
+     ---------------------------------------------------------------------- */
+  --font-display: 'Bricolage Grotesque Variable', system-ui, -apple-system, sans-serif;
+  --font-body: 'Hanken Grotesk Variable', system-ui, -apple-system, sans-serif;
+  --font-mono: 'Fragment Mono', ui-monospace, 'SFMono-Regular', 'Courier New', monospace;
+
+  /* ----------------------------------------------------------------------
+     Palette — modern, fresh, subtle. Cool near-white paper, cool ink, and a
+     single blue accent. Neutrals tinted toward the blue (hue 258). OKLCH.
+     ---------------------------------------------------------------------- */
+  --paper:       oklch(0.988 0.004 258);
+  --paper-sunk:  oklch(0.966 0.006 258);
+  --ink:         oklch(0.225 0.021 260);
+  --ink-soft:    oklch(0.442 0.020 260);
+  --ink-faint:   oklch(0.552 0.017 260);
+
+  --rule:        oklch(0.906 0.006 260);   /* hairlines */
+  --rule-strong: oklch(0.790 0.010 260);   /* visible thin rules */
+
+  --blue:      oklch(0.525 0.165 256);     /* accent fill / marks */
+  --blue-ink:  oklch(0.475 0.150 258);     /* blue as text / links (AA) */
+  --blue-soft: oklch(0.958 0.026 250);     /* subtle blue wash (hero, hover) */
+  --on-blue:   oklch(0.992 0.004 258);     /* text on a solid blue */
+
+  /* ---- Semantic (light) ---- */
+  --color-bg:      var(--paper);
+  --color-surface: var(--paper-sunk);
+  --color-text:    var(--ink);
+  --color-accent:  var(--blue-ink);
+  --color-spark:   var(--blue);
+
+  /* Legacy names kept so existing prose + components restyle automatically. */
+  --color-mid:  var(--rule-strong);
+  --color-grey: var(--ink-soft);
+  --border: 1px solid var(--rule);
+
+  --body-weight: 400;
+  --body-leading: 1.62;
 
   --max-width: 75rem;
   --max-width-content: 45rem;
 
-  --border: 1px solid #e6e6e6;
+  /* ---- Motion ---- */
+  --ease-out-quart: cubic-bezier(0.25, 1, 0.5, 1);
+  --ease-out-quint: cubic-bezier(0.22, 1, 0.36, 1);
+  --dur-fast: 140ms;
+  --dur-mid: 240ms;
+  --dur-slow: 600ms;
 
   /* fontsizes */
   --step--2: clamp(0.78rem, calc(0.77rem + 0.03vw), 0.80rem);
@@ -19,7 +59,7 @@
   --step-3: clamp(1.94rem, calc(1.77rem + 0.87vw), 2.44rem);
   --step-4: clamp(2.33rem, calc(2.08rem + 1.25vw), 3.05rem);
   --step-5: clamp(2.80rem, calc(2.45rem + 1.77vw), 3.82rem);
-
+  --step-6: clamp(3.36rem, calc(2.75rem + 3.05vw), 5.20rem);
 
   /* spacings */
   --space-3xs: clamp(0.31rem, calc(0.31rem + 0.00vw), 0.31rem);
@@ -44,4 +84,59 @@
 
   /* Custom pairs */
   --space-s-l: clamp(1.13rem, calc(0.65rem + 2.39vw), 2.50rem);
+}
+
+/* ---- Dark theme: clean cool dark, blue stays the accent ---- */
+@media (prefers-color-scheme: dark) {
+  :root {
+    --paper:       oklch(0.200 0.016 262);
+    --paper-sunk:  oklch(0.246 0.018 262);
+    --ink:         oklch(0.948 0.008 258);
+    --ink-soft:    oklch(0.742 0.014 260);
+    --ink-faint:   oklch(0.602 0.016 262);
+
+    --rule:        oklch(0.318 0.014 262);
+    --rule-strong: oklch(0.452 0.016 262);
+
+    --blue:      oklch(0.660 0.150 256);
+    --blue-ink:  oklch(0.762 0.130 258);
+    --blue-soft: oklch(0.288 0.045 258);
+    --on-blue:   oklch(0.150 0.020 262);
+
+    --body-weight: 360;
+    --body-leading: 1.70;
+  }
+}
+
+/* Manual override wins in both directions (masthead toggle stamps data-theme). */
+:root[data-theme='light'] {
+  --paper: oklch(0.988 0.004 258);
+  --paper-sunk: oklch(0.966 0.006 258);
+  --ink: oklch(0.225 0.021 260);
+  --ink-soft: oklch(0.442 0.020 260);
+  --ink-faint: oklch(0.552 0.017 260);
+  --rule: oklch(0.906 0.006 260);
+  --rule-strong: oklch(0.790 0.010 260);
+  --blue: oklch(0.525 0.165 256);
+  --blue-ink: oklch(0.475 0.150 258);
+  --blue-soft: oklch(0.958 0.026 250);
+  --on-blue: oklch(0.992 0.004 258);
+  --body-weight: 400;
+  --body-leading: 1.62;
+}
+
+:root[data-theme='dark'] {
+  --paper: oklch(0.200 0.016 262);
+  --paper-sunk: oklch(0.246 0.018 262);
+  --ink: oklch(0.948 0.008 258);
+  --ink-soft: oklch(0.742 0.014 260);
+  --ink-faint: oklch(0.602 0.016 262);
+  --rule: oklch(0.318 0.014 262);
+  --rule-strong: oklch(0.452 0.016 262);
+  --blue: oklch(0.660 0.150 256);
+  --blue-ink: oklch(0.762 0.130 258);
+  --blue-soft: oklch(0.288 0.045 258);
+  --on-blue: oklch(0.150 0.020 262);
+  --body-weight: 360;
+  --body-leading: 1.70;
 }

--- a/src/css/typo.css
+++ b/src/css/typo.css
@@ -1,18 +1,36 @@
-/* Font is self-hosted via @fontsource-variable/roboto-slab, imported in BaseLayout.astro. */
 body {
-  font-family: 'Roboto Slab Variable', serif;
-  font-weight: 300;
-  line-height: 1.7;
+  font-family: var(--font-body);
+  font-weight: var(--body-weight);
+  line-height: var(--body-leading);
   color: var(--color-text);
   font-size: var(--step-0);
+  font-kerning: normal;
+  text-rendering: optimizeLegibility;
+  -webkit-font-smoothing: antialiased;
 }
 
-/* The reset strips heading sizes, so page-level h1/h2 share one scale here.
-   Components that need a bigger title (e.g. a post's .title) override this in scoped styles. */
-h1,
-h2 {
+/* Bricolage Grotesque carries the poster identity: wordmark, hero, titles.
+   Heavy weight, tight tracking, tight leading — confident and graphic. */
+h1, h2, h3,
+.display {
+  font-family: var(--font-display);
+  font-weight: 800;
+  line-height: 0.98;
+  letter-spacing: -0.02em;
+  text-wrap: balance;
+  font-variation-settings: 'opsz' 36;
+}
+
+/* Page-level h1/h2 share one scale here; components override in scoped styles.
+   The reset stripped heading sizes, so set them explicitly. */
+h1, h2 {
   font-size: var(--step-3);
-  font-weight: 400;
   margin-bottom: var(--space-s);
   margin-top: var(--space-l);
+}
+
+/* Fragment Mono for small metadata only — dates, tags, counts. Never prose. */
+.tabular {
+  font-family: var(--font-mono);
+  font-variant-numeric: tabular-nums;
 }

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -2,7 +2,9 @@
 const { pageTitle, frontmatter, lang = "en" } = Astro.props;
 import Header from "../components/Header.astro";
 import Footer from "../components/Footer.astro";
-import "@fontsource-variable/roboto-slab";
+import "@fontsource-variable/bricolage-grotesque";
+import "@fontsource-variable/hanken-grotesk";
+import "@fontsource/fragment-mono";
 import "/src/css/main.css";
 ---
 
@@ -11,6 +13,16 @@ import "/src/css/main.css";
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="theme-color" content="#faf7f0" media="(prefers-color-scheme: light)" />
+    <meta name="theme-color" content="#171a21" media="(prefers-color-scheme: dark)" />
+    <script is:inline>
+      // Apply a stored theme before paint so there is no flash. No stored value
+      // means "auto" — the CSS prefers-color-scheme rules take over.
+      try {
+        var t = localStorage.getItem("theme");
+        if (t === "light" || t === "dark") document.documentElement.dataset.theme = t;
+      } catch (e) {}
+    </script>
     <link rel="canonical" href={Astro.url} />
     <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
     <link

--- a/src/layouts/Home.astro
+++ b/src/layouts/Home.astro
@@ -6,24 +6,47 @@ const allPosts = await getCollection("posts");
 allPosts.sort((a, b) => +b.data.date - +a.data.date);
 
 const { frontmatter } = Astro.props;
+const heading = frontmatter?.heading ?? "Things done, by Simon.";
 ---
 
 <BaseLayout frontmatter={frontmatter}>
-  <header>
-    <h1 class="visually-hidden">{frontmatter.title}</h1>
-    <slot />
-  </header>
+  <section class="hero" aria-labelledby="hero-title">
+    <h1 class="hero__title" id="hero-title">{heading}</h1>
+  </section>
 
-  <section class="home">
-    <h2 class="visually-hidden">Recent stuff</h2>
+  <section class="index" aria-label="All posts">
+    <hr class="index__rule" />
     <PostsList posts={allPosts} />
   </section>
 </BaseLayout>
 
 <style>
-  header {
+  .hero {
+    background: var(--blue);
+    color: var(--on-blue);
+    padding: var(--space-xl) var(--space-l);
+    margin-block: var(--space-xs) var(--space-xl);
+    animation: hero-in var(--dur-slow) var(--ease-out-quint) both;
+  }
+
+  .hero__title {
+    font-family: var(--font-display);
+    font-weight: 800;
+    font-size: var(--step-6);
+    line-height: 0.94;
+    letter-spacing: -0.035em;
+    max-width: 15ch;
+    color: var(--on-blue);
+    margin: 0;
+    font-variation-settings: 'opsz' 48;
+  }
+
+  .index__rule {
     margin-bottom: var(--space-xl);
-    font-size: var(--step-2);
-    font-weight: 400;
+  }
+
+  @keyframes hero-in {
+    from { opacity: 0; transform: translateY(12px); }
+    to   { opacity: 1; transform: translateY(0); }
   }
 </style>

--- a/src/pages/[...slug].astro
+++ b/src/pages/[...slug].astro
@@ -100,7 +100,7 @@ const previewAlt =
   <style>
     header {
       max-width: var(--max-width-content);
-      margin: 0 auto;
+      margin: var(--space-l) auto 0;
     }
 
     div.markdown {
@@ -112,35 +112,65 @@ const previewAlt =
     }
 
     .title {
-      font-size: var(--step-4);
-      font-weight: 400;
-      margin-bottom: var(--space-m);
+      font-family: var(--font-display);
+      font-size: var(--step-5);
+      font-weight: 800;
+      line-height: 0.98;
+      letter-spacing: -0.03em;
+      text-wrap: balance;
+      margin-bottom: var(--space-s);
+      font-variation-settings: 'opsz' 40;
     }
 
     .desc {
       font-size: var(--step-1);
+      line-height: 1.4;
+      color: var(--ink-soft);
       margin-bottom: var(--space-s);
     }
 
     .details {
-      font-size: var(--step--1);
-      color: var(--color-grey);
+      font-family: var(--font-mono);
+      font-size: var(--step--2);
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      color: var(--ink-faint);
       margin-bottom: var(--space-s);
     }
 
     aside {
       max-width: var(--max-width-content);
-      margin: var(--space-xl) auto;
+      margin: var(--space-l) auto var(--space-2xl);
     }
 
     .pagination {
       display: flex;
       justify-content: space-between;
-      align-items: end;
+      align-items: start;
+      gap: var(--space-m);
     }
 
     .pagination > * {
       flex: 1;
+      max-width: 22ch;
+    }
+
+    .pagination a {
+      display: block;
+      font-family: var(--font-display);
+      font-weight: 700;
+      font-size: var(--step-0);
+      line-height: 1.1;
+      letter-spacing: -0.01em;
+      text-decoration: none;
+      color: var(--color-text);
+    }
+
+    .pagination a:hover {
+      color: var(--blue-ink);
+      text-decoration: underline;
+      text-decoration-color: var(--blue);
+      text-underline-offset: 0.2em;
     }
 
     .pagination > *:last-child {

--- a/src/pages/archive.astro
+++ b/src/pages/archive.astro
@@ -7,7 +7,7 @@ allPosts.sort((a, b) => +b.data.date - +a.data.date);
 ---
 
 <BaseLayout pageTitle="The archive">
-  <section class="home">
+  <section class="page">
     <h1>The archive</h1>
     <ArchiveList posts={allPosts} />
   </section>

--- a/src/pages/index.md
+++ b/src/pages/index.md
@@ -1,6 +1,5 @@
 ---
 layout: ../layouts/Home.astro
 title: 'DoneBySimon'
+heading: 'Things done, by Simon.'
 ---
-
-Things done, by Simon.

--- a/src/pages/tags/[tag].astro
+++ b/src/pages/tags/[tag].astro
@@ -30,7 +30,7 @@ const { tag, posts } = Astro.props;
 
 <style>
   span {
-    font-family: "Courier New", Courier, monospace;
-    font-weight: bold;
+    font-family: var(--font-mono);
+    color: var(--blue-ink);
   }
 </style>


### PR DESCRIPTION
Rework the site's look into a modern, fresh, subtle direction with a single bold moment. Keeps long-form readability, adds light/dark theming, and holds WCAG-AA contrast in both themes (verified with an OKLCH validator).

Type & palette:
- Bricolage Grotesque (display), Hanken Grotesk (body), Fragment Mono (metadata), all self-hosted via @fontsource; drop the unused roboto-slab dependency.
- New OKLCH palette: cool near-white paper, cool ink, a single blue accent; neutrals tinted toward the blue. Legacy token names remapped so prose restyles automatically (also fixes meta text that failed AA at #979797 on white).

Homepage & components:
- Bold solid-blue hero block with a big Bricolage headline (no tagline).
- Post entries: full-colour photos, bold titles, mono date + tags, quiet blue title-underline on hover/focus (no image zoom), no post numbering.
- Add a persisted light/dark ThemeToggle with a no-flash init script.
- Restyle masthead, footer (wordmark + links), tags, archive/blog lists, post detail page, and 404 to match.
- Prose: replace the border-left blockquote (anti-pattern) with a subtle tint, modernise inline code, correct heading/strong weights.

Add .impeccable.md and CLAUDE.md capturing the design context.